### PR TITLE
[002]: Añadir vicepresidencia al modelo

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -20,7 +20,8 @@ class Database:
                 "fictional_votes": 42000,
                 "slogan": "To infinity and beyond taxes!",
                 "age": 45,
-                "campaign_budget": 3000000.0
+                "campaign_budget": 3000000.0,
+                "vice_name": "Admiral Nebula"
             },
             {
                 "name": "Lady Naps-A-Lot",
@@ -30,7 +31,8 @@ class Database:
                 "fictional_votes": 56000,
                 "slogan": "A pillow in every office!",
                 "age": 39,
-                "campaign_budget": 1500000.0
+                "campaign_budget": 1500000.0,
+                "vice_name": "Sir Snooze"
             },
             {
                 "name": "Professor Meme",
@@ -40,7 +42,8 @@ class Database:
                 "fictional_votes": 38000,
                 "slogan": "Such leadership. Very democracy. Wow.",
                 "age": 33,
-                "campaign_budget": 750000.0
+                "campaign_budget": 750000.0,
+                "vice_name": "Doge McVice"
             }
         ]
         
@@ -53,12 +56,13 @@ class Database:
                 fictional_votes=candidate_data["fictional_votes"],
                 slogan=candidate_data["slogan"],
                 age=candidate_data["age"],
-                campaign_budget=candidate_data["campaign_budget"]
+                campaign_budget=candidate_data["campaign_budget"], 
+                vice_name=candidate_data["vice_name"] 
             )
     
     def add_candidate(self, name: str, party: str, main_proposal: str, 
                      populism_level: int, fictional_votes: int, slogan: str, 
-                     age: int, campaign_budget: float) -> CandidateModel:
+                     age: int, campaign_budget: float, vice_name=None) -> CandidateModel:
         """Añade un nuevo candidato a la base de datos."""
         new_candidate = CandidateModel(
             id=self.counter,
@@ -70,6 +74,7 @@ class Database:
             slogan=slogan,
             age=age,
             campaign_budget=campaign_budget,
+            vice_name=vice_name,
             created_at=datetime.now()
         )
         self.candidates.append(new_candidate)

--- a/app/models/candidate.py
+++ b/app/models/candidate.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 class CandidateModel:
     def __init__(self, id: int, name: str, party: str, main_proposal: str, 
                  populism_level: int, fictional_votes: int, slogan: str, 
-                 age: int, campaign_budget: float, created_at: datetime):
+                 age: int, campaign_budget: float, created_at: datetime, vice_name=None):
         self.id = id
         self.name = name
         self.party = party
@@ -15,6 +15,7 @@ class CandidateModel:
         self.slogan = slogan
         self.age = age
         self.campaign_budget = campaign_budget
+        self.vice_name = vice_name
         self.created_at = created_at or datetime.now(timezone.utc)
     
     def to_dict(self) -> Dict:
@@ -28,6 +29,7 @@ class CandidateModel:
             "slogan": self.slogan,
             "age": self.age,
             "campaign_budget": self.campaign_budget,
+            "vice_name": self.vice_name,
             "created_at": self.created_at.isoformat()
         }
     
@@ -43,5 +45,6 @@ class CandidateModel:
             slogan=data["slogan"],
             age=data["age"],
             campaign_budget=data["campaign_budget"],
+            vice_name=data.get("vice_name"),
             created_at=datetime.fromisoformat(data["created_at"]) if isinstance(data["created_at"], str) else data["created_at"]
         )

--- a/app/routers/candidates.py
+++ b/app/routers/candidates.py
@@ -61,7 +61,8 @@ async def create_candidate(candidate: CandidateCreate):
         fictional_votes=candidate.fictional_votes,
         slogan=candidate.slogan,
         age=candidate.age,
-        campaign_budget=candidate.campaign_budget
+        campaign_budget=candidate.campaign_budget,
+        vice_name=candidate.vice_name
     )
     return new_candidate
 

--- a/app/schemas/candidate.py
+++ b/app/schemas/candidate.py
@@ -11,6 +11,7 @@ class CandidateBase(BaseModel):
     slogan: str = Field(..., min_length=5, max_length=200, description="Eslogan de campaña")
     age: int = Field(..., ge=18, le=120, description="Edad del candidato")
     campaign_budget: float = Field(..., ge=0, description="Presupuesto de campaña en dólares")
+    vice_name: Optional[str] = Field(None, max_length=100, description="Nombre del vicepresidente/a")
 
     @field_validator('populism_level')
     @classmethod


### PR DESCRIPTION
## ✨ Descripción de los cambios

<!-- Describe los cambios que has realizado en este PR -->
Este cambio introduce el campo `vice_name` (nombre del vicepresidente) como atributo opcional para cada candidato. Se ha actualizado lo siguiente:

- El modelo `CandidateModel` (en `models/candidate.py`) para incluir `vice_name`.
- Los esquemas de Pydantic en `schemas/candidate.py` (`CandidateBase`, `CandidateCreate`, `Candidate`, `CandidateUpdate`).
- La base de datos ficticia en `db/database.py`, incluyendo:
    - El método `add_candidate()` acepta ahora `vice_name`.
    - La función `_initialize_data()` incluye vicepresidentes ficticios para los candidatos de ejemplo.
  
## ✅ Tipo de cambio

- [x] Nueva característica (cambio que añade funcionalidad sin romper compatibilidad)
- [ ] Corrección de error (cambio que corrige un problema sin romper compatibilidad)
- [ ] Cambio importante (cambio que rompe compatibilidad con versiones anteriores)
- [ ] Actualización de la documentación

## 🧪 Cómo probar los cambios

<!-- Describe el proceso que tus compañeros deben seguir para verificar tus cambios -->
 1.  Ejecutar el proyecto y crear un nuevo candidato con el campo vice_name incluido, por ejemplo:

```json
{
  "name": "Sir Nibbles",
  "party": "Feline First Party",
  "main_proposal": "Mandatory cat nap time for all citizens",
  "populism_level": 95,
  "fictional_votes": 67000,
  "slogan": "A mouse in every house!",
  "age": 47,
  "campaign_budget": 2500000.0,
  "vice_name": "General Whiskers"
}
```

2. Verificar que la respuesta de la API incluya el campo `vice_name`.
    
3. Comprobar que los candidatos iniciales ya cargan con `vice_name` en la base de datos simulada.
    
4. Ejecutar los tests con `pytest` y confirmar que todos pasan correctamente.

## 📸 Capturas de pantalla (si aplica)

<!-- Añade capturas de pantalla si es necesario -->
*No aplica para este cambio.*
